### PR TITLE
Feature/signup

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RegistrationsController < Devise::RegistrationsController
+  protected
+
+  def after_sign_up_path_for(_resource)
+    sign_out current_user
+    new_user_session_path
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,0 +1,1 @@
+Dashboard

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,7 +23,7 @@
         </div>
       </div>
       <div class="flex flex-col">
-        <%= form.submit "Sing up", class: "h-[44px] rounded-md text-white w-full bg-light-gray font-bold text-white outline-none cursor-not-allowed", id: "submitButton" %>
+        <%= form.submit "Sign up", class: "h-[44px] rounded-md text-white w-full bg-light-gray font-bold text-white outline-none cursor-not-allowed", id: "submitButton" %>
       </div>
       <div class="invisible text-red-500 text-center" id="error"></div>
       <p class="alert text-red-500 text-center" id="alertText"><%= alert %></p>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,40 @@
+<div class="flex h-[100vh] flex-col bg-cover bg-center bg-no-repeat px-6 py-16 text-base text-dark-violet md:px-28">
+  <div class="h-[496px] max-w-[328px] rounded-lg border-black bg-white px-[34px] md:h-[572px] md:max-w-[360px]">
+    <div class="pb-5 pt-[40px] md:p-[47px] md:pb-7">
+      <%= render LogoComponent.new(title: 'Sign Up', type: 'black') %>
+    </div>
+    <%= form_for resource, as: resource_name, url: registration_path(resource_name), data: { controller: "validate-form" } do |form| %>
+      <div class="my-4 flex flex-col">
+        <%= form.label :email, class: "text-sm md:text-base" %>
+        <%= form.email_field :email, autofocus: true, autocomplete: "email", class: "border text-black custom-focus h-[34px] w-auto rounded-md border border-dark-violet ps-3 placeholder:text-base placeholder:text-dark-gray hover:border-hover active:outline-none active:ring-2 active:ring-offset-2 md:h-[44px]", placeholder: "Type your email", type: "email" %>
+      </div>
+      <div class="relative my-4">
+        <%= form.label :password, class: "text-sm md:text-base" %>
+        <div class="flex flex-col">
+          <%= form.password_field :password, autocomplete: "new-password", class: "border custom-focus h-[34px] w-auto rounded-md border border-dark-violet ps-3 placeholder:text-base placeholder:text-dark-gray hover:border-hover active:outline-none active:ring-2 active:ring-offset-2 md:h-[44px]", placeholder: "Type your password" %>
+          <%= render(ButtonVisibilityComponent.new()) %>
+        </div>
+      </div>
+      <div class="relative my-4" >
+        <%= form.label :confirm_password, class: "text-sm md:text-base" %>
+        <div class="flex flex-col">
+          <%= form.password_field :password_confirmation, autocomplete: "new-password", class: "border custom-focus h-[34px] w-auto rounded-md border border-dark-violet ps-3 placeholder:text-base placeholder:text-dark-gray hover:border-hover active:outline-none active:ring-2 active:ring-offset-2 md:h-[44px]", placeholder: "Type your password" %>
+          <%= render(ButtonVisibilityComponent.new()) %>
+        </div>
+      </div>
+      <div class="flex flex-col">
+        <%= form.submit "Sing up", class: "h-[44px] rounded-md text-white w-full bg-light-gray font-bold text-white outline-none cursor-not-allowed", id: "submitButton" %>
+      </div>
+      <div class="invisible text-red-500 text-center" id="error"></div>
+      <p class="alert text-red-500 text-center" id="alertText"><%= alert %></p>
+      <%= render "devise/shared/error_messages", resource: resource %>
+    <% end %>
+    <div class="mt-5 text-center">By signing up, you accept the
+      <a class="link-focus link-hover link-active" href="/data_policy">Data Policy</a> and the
+      <a class="link-focus link-hover link-active" href="/cookies_policy">Cookies Policy.</a>
+    </div>
+    <div class="mt-5 text-center">Already have an account?
+      <%= link_to 'Log in', new_user_session_path, class: "link-focus link-hover link-active" %>
+    </div>
+  </div>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -29,7 +29,7 @@
     <div class="m-4 text-center">Don't have an account?</div>
     <Link href="/signup" tabIndex={-1}>
     <div class="mx-[34px] flex flex-col">
-      <%= link_to 'Sing up', new_user_registration_path, class: "py-2 item-center h-[44px] rounded-md border text-center font-bold bg-white text-black border-dark-violet active:ring-2 active:ring-offset-2 active:outline-none custom-focus hover:bg-hover active:bg-hover" %>
+      <%= link_to 'Sign up', new_user_registration_path, class: "py-2 item-center h-[44px] rounded-md border text-center font-bold bg-white text-black border-dark-violet active:ring-2 active:ring-offset-2 active:outline-none custom-focus hover:bg-hover active:bg-hover" %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/dashboard.erb
+++ b/app/views/layouts/dashboard.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hotwire</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body class="bg-white text-black">
+    <%= yield %>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users, controllers: { sessions: 'sessions' }
+  devise_for :users, controllers: { registrations: 'registrations' }
   get 'errors/not_found'
   get 'errors/internal_server_error'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users, controllers: { registrations: 'registrations' }
+  devise_for :users, controllers: { sessions: 'sessions', registrations: 'registrations' }
   get 'errors/not_found'
   get 'errors/internal_server_error'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RegistrationsController do
+  before do
+    set_devise_mapping
+  end
+
+  describe '#create' do
+    let(:user_attributes) { attributes_for(:user, password: '12345678', password_confirmation: '12345678') }
+
+    context 'when valid user attributes are provided' do
+      it 'creates a new user' do
+        expect {
+          post :create, params: { user: user_attributes }
+        }.to change(User, :count).by(1)
+      end
+
+      it 'redirects to the sign in page' do
+        post :create, params: { user: user_attributes }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'when invalid user attributes are provided' do
+      let(:user_attributes) { attributes_for(:user, password: '12345', password_confirmation: '12345678') }
+
+      it 'does not create a new user' do
+        expect {
+          post :create, params: { user: user_attributes }
+        }.not_to change(User, :count)
+      end
+
+      it 'renders the same form' do
+        post :create, params: { user: user_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Board:
* [Sing up](https://trello.com/c/ouXyfw2S/16-3-as-a-user-i-should-be-able-to-sign-up-to-create-an-account)
---
#### Description:
-  As a user I should be able to Sign Up to create an account
---
#### Notes:
- This PR depends from sign-in branch
---
#### Tasks:
Acceptance Criteria

- [x] Given that I am logged out
- [x] When I go to the homepage
- [x] Then I should land on the login page and see a sign up link
- [x] When I click it
- [x] Then I should be redirected to the sign up page and see a form to sign up
- [x] When I fill the form correctly
- [x] Then my account should be created and I should be redirected to the logged in homepage
- [x] When I fill the form incorrectly
- [x] Then I should see an error message indicating my mistakes
- [x] Then I should also see a sign in link
- [x] When I click it
- [x] Then I should be redirected to the sign in page


A11y Checks
- [x] Sign up link
- [x] The "Sign up" anchor should be accessibile by keyboard navigation
- [x] The focus order to reach the "Sign up" anchor should be consistent with the layout order
- [x] The "Sign up" anchor should have distinct styles for hover, focus and active
- [x] Note the use of word anchor and not button, the user is being taken to another page so it should be a link



Sign up form

- [x] We don't have a clear title for the page. In this case for screen readers, we can add an h1 "Sign up" title that is visually hidden but available for screen readers. For more information on how to achieve this read the following links: Screen reader text and .sr-only class
- [x] Each input of the form should have a label correctly asociated
- [x] Error messages that occur in the form should be announced to the user Form errors and Accessible React forms
- [x] All inputs and the submit button should be accessible by keyboard and follow a logical focus order according to the layout
- [x] Add autofill to the inputs that users commonly fill for other sites like: "Name", "Email, and maybe "Gender"
- [x] Other links that redirect to different pages should be keyboard-accessible anchors (Note that if an anchor doesn't have an href is not keyboard accessible)
- [x] "Show password" button (eye icon)
- [x] "Show password" button should have a label for screen reader users.
- [x] Since it's a button should receive focus. (Note: the focus should be after password input and before the input error).
- [x] Since the button has two states (show/hide) add the corresponding aria-pressed. Read sections "Changing states" and - - [x] "Changing labels" here: Toggle buttons

Others
- [x] Background image should be decorative. Image alt texts
---
#### Preview:
[Screencast from 2024-01-30 13-14-36.webm](https://github.com/frankvielma/rs-blackmarket-hotwire/assets/412081/0e080e7a-772c-418f-9b34-7932da965fab)

