### PR TITLE
add sign out

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -40,10 +40,9 @@
           </svg>
         </button>
       </div>
-          <div class="py-2 px-4 cursor-pointer hover:bg-gray-100 border-gray text-base hover:bg-hover" >
-      <%= link_to "Sign out", '#' %>
-    </div>
-
+      <div class="py-2 px-4 cursor-pointer hover:bg-gray-100 border-gray text-base hover:bg-hover">
+        <%= link_to "Sign out", destroy_user_session_path, data: {turbo_method: :delete} %>
+      </div>
     </nav>
   </div>
 </header>

--- a/app/components/myaccount_component.html.erb
+++ b/app/components/myaccount_component.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div id="dropdownMenu" class="hidden w-40 text-base absolute top-50 rounded-md border-white bg-black text-white">
     <div class="py-2 px-4 cursor-pointer hover:bg-gray-100 border-gray border-b-[1px] hover:bg-hover" >
-      <%= link_to "Sign out", '#' %>
+      <%= link_to "Sign out", destroy_user_session_path, data: { turbo_method: :delete } %>
     </div>
   </div>
 </div>

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -34,4 +34,18 @@ RSpec.describe SessionsController do
       end
     end
   end
+
+  describe '#destroy' do
+    let(:user_attributes) { attributes_for(:user, password: '12345678', password_confirmation: '12345678') }
+
+    it 'logs out the user and redirects to the root path' do
+      create(:user, user_attributes)
+      post :create, params: { user: user_attributes }
+
+      delete :destroy
+
+      expect(response).to redirect_to(root_path)
+      expect(controller.current_user).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
#### Board:
* [Sign out](https://trello.com/c/NIJ8U4v3/18-1-as-a-user-i-should-be-able-to-sign-out-from-my-current-session)
---
#### Description:
- As a user, I should be able to Sign Out from my current session
---
#### Notes:
- This PR depends from dashboard_header branch
---
#### Tasks:
Acceptance Criteria

- [x] Given that I am signed in
- [x] When I visit any page in the site
- [x] Then I should see a navbar with a "My Account" menu dropdown
- [x] When I open the dropdown
- [x] Then I should see the sign out button
- [x] When I click it
- [x] Then I should be signed out and redirected to the sign in page

A11y Checks
- [x] The Log out CTA should be a button since it is performing an action, it is not directly a link although it ends up taking you to another page.
- [x] For more info on how to make the dropdown menu accessible follow this guide
---

#### Preview:

[Screencast from 2024-01-31 09-20-53.webm](https://github.com/frankvielma/rs-blackmarket-hotwire/assets/412081/951606af-4b2c-44b4-ab5e-1cba37a95dac)


